### PR TITLE
Create interactive football pick tracker

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,802 @@
+const storageKey = 'football-pick-tracker';
+
+const state = {
+  games: [],
+  editingGameId: null,
+  editingPrediction: null,
+  filterText: '',
+};
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(16).slice(2)}-${Date.now()}`;
+}
+
+const selectors = {
+  gamesContainer: document.getElementById('gamesContainer'),
+  snapshot: document.getElementById('snapshot'),
+  searchInput: document.getElementById('searchInput'),
+  addGameBtn: document.getElementById('addGameBtn'),
+  sampleDataBtn: document.getElementById('sampleDataBtn'),
+  exportDataBtn: document.getElementById('exportDataBtn'),
+  importDataBtn: document.getElementById('importDataBtn'),
+  importFileInput: document.getElementById('importFileInput'),
+  emptyTemplate: document.getElementById('emptyStateTemplate'),
+};
+
+const dialogs = {
+  game: document.getElementById('gameDialog'),
+  prediction: document.getElementById('predictionDialog'),
+};
+
+const forms = {
+  game: document.getElementById('gameForm'),
+  prediction: document.getElementById('predictionForm'),
+};
+
+const outputs = {
+  confidence: dialogs.prediction.querySelector('[data-confidence-output]'),
+};
+
+const texts = {
+  gameDialogTitle: document.getElementById('gameDialogTitle'),
+  predictionDialogTitle: document.getElementById('predictionDialogTitle'),
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  hydrate();
+  bindEvents();
+  render();
+});
+
+function hydrate() {
+  const raw = localStorage.getItem(storageKey);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed.games)) {
+        state.games = normalizeGames(parsed.games);
+        return;
+      }
+    } catch (error) {
+      console.warn('Unable to parse stored data, falling back to sample slate.', error);
+    }
+  }
+  state.games = sampleSlate();
+}
+
+function bindEvents() {
+  selectors.addGameBtn.addEventListener('click', () => openGameDialog());
+  selectors.sampleDataBtn.addEventListener('click', () => {
+    if (confirm('Replace your current board with the curated sample slate?')) {
+      state.games = sampleSlate();
+      persist();
+      render();
+    }
+  });
+  selectors.exportDataBtn.addEventListener('click', exportData);
+  selectors.importDataBtn.addEventListener('click', () => selectors.importFileInput.click());
+  selectors.importFileInput.addEventListener('change', handleImportFile);
+
+  selectors.searchInput.addEventListener('input', (event) => {
+    state.filterText = event.target.value.trim().toLowerCase();
+    renderGames();
+  });
+
+  forms.game.addEventListener('submit', handleGameSubmit);
+  forms.prediction.addEventListener('submit', handlePredictionSubmit);
+
+  dialogs.game.addEventListener('click', handleDialogClick);
+  dialogs.prediction.addEventListener('click', handleDialogClick);
+
+  dialogs.game.addEventListener('close', () => {
+    state.editingGameId = null;
+    forms.game.reset();
+  });
+  dialogs.prediction.addEventListener('close', () => {
+    state.editingPrediction = null;
+    forms.prediction.reset();
+    forms.prediction.confidence.value = 50;
+    outputs.confidence.textContent = '50%';
+  });
+
+  outputs.confidence.textContent = `${forms.prediction.confidence.value}%`;
+  forms.prediction.confidence.addEventListener('input', (event) => {
+    outputs.confidence.textContent = `${event.target.value}%`;
+  });
+
+  selectors.gamesContainer.addEventListener('click', handleGameAction);
+}
+
+function persist() {
+  localStorage.setItem(storageKey, JSON.stringify({ games: state.games }));
+}
+
+function render() {
+  renderGames();
+  renderSnapshot();
+}
+
+function renderGames() {
+  const container = selectors.gamesContainer;
+  container.innerHTML = '';
+
+  const games = state.games.filter((game) => filterGame(game, state.filterText));
+
+  if (!games.length) {
+    const empty = selectors.emptyTemplate.content.cloneNode(true);
+    empty.querySelector('[data-empty-add]').addEventListener('click', () => openGameDialog());
+    container.appendChild(empty);
+    return;
+  }
+
+  games.forEach((game) => {
+    container.appendChild(renderGameCard(game));
+  });
+}
+
+function filterGame(game, needle) {
+  if (!needle) return true;
+  const haystack = [
+    game.homeTeam,
+    game.awayTeam,
+    game.location,
+    game.kickoff,
+    ...(game.tags || []),
+    game.notes,
+    ...game.predictions.flatMap((prediction) => [
+      prediction.source,
+      prediction.market,
+      prediction.pick,
+      prediction.notes,
+    ]),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+function renderGameCard(game) {
+  const card = document.createElement('article');
+  card.className = 'game-card';
+  card.dataset.gameId = game.id;
+
+  const header = document.createElement('header');
+  header.className = 'game-header';
+
+  const topRow = document.createElement('div');
+  topRow.className = 'game-header__top';
+
+  const title = document.createElement('h2');
+  title.className = 'game-title';
+  title.textContent = `${game.awayTeam} @ ${game.homeTeam}`;
+  topRow.appendChild(title);
+
+  if (game.tags?.length) {
+    game.tags.slice(0, 4).forEach((tag) => {
+      const chip = document.createElement('span');
+      chip.className = 'tag-chip';
+      chip.textContent = tag.trim();
+      topRow.appendChild(chip);
+    });
+  }
+
+  header.appendChild(topRow);
+
+  const meta = document.createElement('div');
+  meta.className = 'game-meta';
+  if (game.kickoff) {
+    const kickoff = document.createElement('span');
+    kickoff.textContent = `Kickoff: ${game.kickoff}`;
+    meta.appendChild(kickoff);
+  }
+  if (game.location) {
+    const location = document.createElement('span');
+    location.textContent = game.location;
+    meta.appendChild(location);
+  }
+
+  const summary = buildConsensusSummary(game.predictions);
+  if (summary) {
+    const banner = document.createElement('div');
+    banner.className = 'summary-banner';
+    banner.innerHTML = `<strong>${summary.pick}</strong><span>${summary.count} of ${summary.total} sources (${summary.percent}%)`;
+    header.appendChild(banner);
+  }
+
+  header.appendChild(meta);
+
+  if (game.notes) {
+    const notes = document.createElement('p');
+    notes.className = 'game-notes';
+    notes.textContent = game.notes;
+    notes.style.color = 'var(--text-muted)';
+    notes.style.fontSize = '0.9rem';
+    notes.style.lineHeight = '1.5';
+    header.appendChild(notes);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'game-actions';
+  actions.innerHTML = `
+    <button class="btn" data-action="edit-game">✏️ Edit</button>
+    <button class="btn btn--ghost" data-action="add-prediction">➕ Add Pick</button>
+    <button class="btn btn--ghost" data-action="delete-game">🗑️ Delete</button>
+  `;
+
+  header.appendChild(actions);
+  card.appendChild(header);
+
+  const markets = groupBy(game.predictions, (prediction) => prediction.market || 'General Picks');
+  if (markets.size) {
+    markets.forEach((predictions, market) => {
+      card.appendChild(renderMarketBlock(game, market, predictions));
+    });
+  } else {
+    const emptyMarket = document.createElement('div');
+    emptyMarket.className = 'market-block';
+    emptyMarket.innerHTML = `
+      <div class="market-header">
+        <div class="market-title">
+          <h3>Start building your board</h3>
+        </div>
+        <p class="market-meta">No picks yet. Add insights from your favorite experts.</p>
+      </div>
+      <button class="btn btn--primary" data-action="add-prediction">Add first pick</button>
+    `;
+    card.appendChild(emptyMarket);
+  }
+
+  return card;
+}
+
+function renderMarketBlock(game, market, predictions) {
+  const block = document.createElement('section');
+  block.className = 'market-block';
+  block.dataset.market = market;
+
+  const header = document.createElement('div');
+  header.className = 'market-header';
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'market-title';
+
+  const title = document.createElement('h3');
+  title.textContent = market;
+  titleRow.appendChild(title);
+
+  const meta = document.createElement('span');
+  meta.className = 'market-meta';
+  meta.textContent = `${predictions.length} pick${predictions.length === 1 ? '' : 's'}`;
+  titleRow.appendChild(meta);
+
+  header.appendChild(titleRow);
+  header.appendChild(buildSummaryBar(predictions));
+
+  const list = document.createElement('ul');
+  list.className = 'prediction-list';
+
+  const sorted = [...predictions].sort((a, b) => {
+    const left = typeof a.confidence === 'number' ? a.confidence : -1;
+    const right = typeof b.confidence === 'number' ? b.confidence : -1;
+    return right - left;
+  });
+
+  sorted.forEach((prediction) => {
+    list.appendChild(renderPredictionItem(game, prediction));
+  });
+
+  block.appendChild(header);
+  block.appendChild(list);
+
+  return block;
+}
+
+function renderPredictionItem(game, prediction) {
+  const item = document.createElement('li');
+  item.className = 'prediction';
+  item.dataset.predictionId = prediction.id;
+  item.dataset.gameId = game.id;
+
+  const source = document.createElement('div');
+  source.className = 'prediction__source';
+  source.textContent = prediction.source;
+
+  const pick = document.createElement('div');
+  pick.className = 'prediction__pick';
+  const pill = document.createElement('span');
+  pill.className = 'pick-pill';
+  pill.style.background = colorForString(prediction.pick, 0.16);
+  pill.style.borderColor = colorForString(prediction.pick, 0.35);
+  pill.textContent = prediction.pick;
+  pick.appendChild(pill);
+  if (prediction.market) {
+    const marketTag = document.createElement('span');
+    marketTag.className = 'tag-chip';
+    marketTag.textContent = prediction.market;
+    pick.appendChild(marketTag);
+  }
+
+  const line = document.createElement('div');
+  line.className = 'prediction__line';
+  line.textContent = prediction.line || '';
+
+  const confidence = document.createElement('div');
+  confidence.className = 'prediction__confidence';
+  if (typeof prediction.confidence === 'number') {
+    const meter = document.createElement('div');
+    meter.className = 'confidence-meter';
+    meter.style.setProperty('--confidence', `${prediction.confidence}%`);
+    const label = document.createElement('div');
+    label.className = 'confidence-label';
+    label.textContent = `${prediction.confidence}% confidence`;
+    confidence.appendChild(meter);
+    confidence.appendChild(label);
+  }
+
+  const notes = document.createElement('div');
+  notes.className = 'prediction__notes';
+  if (prediction.notes) {
+    const noteSpan = document.createElement('span');
+    noteSpan.textContent = prediction.notes;
+    notes.appendChild(noteSpan);
+  }
+  if (prediction.link) {
+    if (notes.childNodes.length) {
+      const separator = document.createElement('span');
+      separator.textContent = ' · ';
+      notes.appendChild(separator);
+    }
+    const anchor = document.createElement('a');
+    anchor.href = prediction.link;
+    anchor.target = '_blank';
+    anchor.rel = 'noopener noreferrer';
+    anchor.textContent = 'Source';
+    notes.appendChild(anchor);
+  }
+  if (!notes.childNodes.length) {
+    notes.textContent = '—';
+    notes.style.color = 'rgba(248, 250, 252, 0.35)';
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'prediction__actions';
+  actions.innerHTML = `
+    <button class="icon-btn" title="Edit" data-action="edit-prediction">✏️</button>
+    <button class="icon-btn" title="Delete" data-action="delete-prediction">🗑️</button>
+  `;
+
+  item.appendChild(source);
+  item.appendChild(pick);
+  item.appendChild(line);
+  item.appendChild(confidence);
+  item.appendChild(notes);
+  item.appendChild(actions);
+
+  return item;
+}
+
+function buildSummaryBar(predictions) {
+  const counts = groupBy(predictions, (prediction) => prediction.pick || 'Other');
+  const bar = document.createElement('div');
+  bar.className = 'summary-bar';
+
+  const entries = [...counts.entries()].sort((a, b) => b[1].length - a[1].length);
+  entries.forEach(([key, value]) => {
+    const segment = document.createElement('div');
+    segment.className = 'summary-segment';
+    segment.style.flex = value.length;
+    segment.style.background = colorForString(key, 0.22);
+    segment.textContent = `${key} (${value.length})`;
+    bar.appendChild(segment);
+  });
+
+  if (!bar.children.length) {
+    bar.style.justifyContent = 'center';
+    bar.style.padding = '0.5rem';
+    bar.textContent = 'No picks logged';
+  }
+
+  return bar;
+}
+
+function buildConsensusSummary(predictions) {
+  if (!predictions.length) return null;
+  const counts = new Map();
+  for (const prediction of predictions) {
+    const key = (prediction.pick || 'Other').trim();
+    if (!counts.has(key)) counts.set(key, 0);
+    counts.set(key, counts.get(key) + 1);
+  }
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const [pick, count] = sorted[0];
+  const total = predictions.length;
+  const percent = Math.round((count / total) * 100);
+  if (percent < 40) return null;
+  return { pick, count, total, percent };
+}
+
+function handleGameSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(forms.game);
+
+  const payload = {
+    id: state.editingGameId ?? generateId(),
+    homeTeam: formData.get('homeTeam').trim(),
+    awayTeam: formData.get('awayTeam').trim(),
+    kickoff: formData.get('kickoff').trim(),
+    location: formData.get('location').trim(),
+    tags: formData
+      .get('tags')
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+    notes: formData.get('notes').trim(),
+  };
+
+  if (!payload.homeTeam || !payload.awayTeam) {
+    alert('Home and away teams are required.');
+    return;
+  }
+
+  const existingIndex = state.games.findIndex((game) => game.id === payload.id);
+  if (existingIndex >= 0) {
+    const existingPredictions = state.games[existingIndex].predictions || [];
+    state.games[existingIndex] = { ...payload, predictions: existingPredictions };
+  } else {
+    state.games.push({ ...payload, predictions: [] });
+  }
+
+  state.editingGameId = null;
+  persist();
+  render();
+  closeDialog(dialogs.game);
+}
+
+function handlePredictionSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(forms.prediction);
+  if (!state.editingPrediction?.gameId) {
+    alert('Please select a game before saving a prediction.');
+    return;
+  }
+  const payload = {
+    id: state.editingPrediction?.id ?? generateId(),
+    source: formData.get('source').trim(),
+    market: formData.get('market').trim(),
+    pick: formData.get('pick').trim(),
+    line: formData.get('line').trim(),
+    confidence: Number(formData.get('confidence')),
+    notes: formData.get('notes').trim(),
+    link: formData.get('link').trim(),
+  };
+
+  if (!payload.source || !payload.pick) {
+    alert('Source and pick are required.');
+    return;
+  }
+
+  const game = state.games.find((g) => g.id === state.editingPrediction.gameId);
+  if (!game) {
+    console.error('Could not locate game for prediction.');
+    return;
+  }
+
+  const existingIndex = game.predictions.findIndex((prediction) => prediction.id === payload.id);
+  if (existingIndex >= 0) {
+    game.predictions[existingIndex] = { ...game.predictions[existingIndex], ...payload };
+  } else {
+    game.predictions.push(payload);
+  }
+
+  state.editingPrediction = null;
+  persist();
+  render();
+  closeDialog(dialogs.prediction);
+}
+
+function handleGameAction(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+
+  const card = event.target.closest('.game-card');
+  if (!card) return;
+  const gameId = card.dataset.gameId;
+  const game = state.games.find((item) => item.id === gameId);
+  if (!game) return;
+
+  switch (button.dataset.action) {
+    case 'add-prediction':
+      openPredictionDialog(game);
+      break;
+    case 'edit-game':
+      openGameDialog(game);
+      break;
+    case 'delete-game':
+      deleteGame(gameId);
+      break;
+    case 'edit-prediction': {
+      const predictionId = button.closest('.prediction').dataset.predictionId;
+      const prediction = game.predictions.find((item) => item.id === predictionId);
+      if (prediction) {
+        openPredictionDialog(game, prediction);
+      }
+      break;
+    }
+    case 'delete-prediction': {
+      const predictionId = button.closest('.prediction').dataset.predictionId;
+      deletePrediction(gameId, predictionId);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function deleteGame(gameId) {
+  if (!confirm('Delete this game and all associated picks?')) return;
+  state.games = state.games.filter((game) => game.id !== gameId);
+  persist();
+  render();
+}
+
+function deletePrediction(gameId, predictionId) {
+  const game = state.games.find((item) => item.id === gameId);
+  if (!game) return;
+  game.predictions = game.predictions.filter((prediction) => prediction.id !== predictionId);
+  persist();
+  render();
+}
+
+function openGameDialog(game) {
+  texts.gameDialogTitle.textContent = game ? 'Edit Game' : 'Add Game';
+  state.editingGameId = game?.id ?? null;
+  forms.game.reset();
+  if (game) {
+    forms.game.homeTeam.value = game.homeTeam || '';
+    forms.game.awayTeam.value = game.awayTeam || '';
+    forms.game.kickoff.value = game.kickoff || '';
+    forms.game.location.value = game.location || '';
+    forms.game.tags.value = (game.tags || []).join(', ');
+    forms.game.notes.value = game.notes || '';
+  }
+  openDialog(dialogs.game);
+}
+
+function openPredictionDialog(game, prediction) {
+  texts.predictionDialogTitle.textContent = prediction ? 'Edit Prediction' : 'Add Prediction';
+  state.editingPrediction = { gameId: game.id, id: prediction?.id };
+  forms.prediction.reset();
+  forms.prediction.confidence.value = prediction?.confidence ?? 50;
+  outputs.confidence.textContent = `${forms.prediction.confidence.value}%`;
+  forms.prediction.source.value = prediction?.source ?? '';
+  forms.prediction.market.value = prediction?.market ?? '';
+  forms.prediction.pick.value = prediction?.pick ?? '';
+  forms.prediction.line.value = prediction?.line ?? '';
+  forms.prediction.link.value = prediction?.link ?? '';
+  forms.prediction.notes.value = prediction?.notes ?? '';
+  openDialog(dialogs.prediction);
+}
+
+function handleDialogClick(event) {
+  if (event.target.matches('[data-close-dialog]')) {
+    closeDialog(event.currentTarget);
+  }
+}
+
+function closeDialog(dialog) {
+  dialog.close();
+}
+
+function openDialog(dialog) {
+  if (typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  } else {
+    dialog.setAttribute('open', '');
+  }
+}
+
+function groupBy(items, getKey) {
+  const map = new Map();
+  for (const item of items) {
+    const key = typeof getKey === 'function' ? getKey(item) : item[getKey];
+    if (!map.has(key)) {
+      map.set(key, []);
+    }
+    map.get(key).push(item);
+  }
+  return map;
+}
+
+function colorForString(input, alpha = 0.25) {
+  const string = input || 'default';
+  let hash = 0;
+  for (let i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsla(${hue}, 70%, 60%, ${alpha})`;
+}
+
+function renderSnapshot() {
+  const snapshot = selectors.snapshot;
+  snapshot.innerHTML = '';
+  const totalGames = state.games.length;
+  const totalPicks = state.games.reduce((acc, game) => acc + game.predictions.length, 0);
+  const highConfidence = state.games
+    .flatMap((game) => game.predictions)
+    .filter((prediction) => typeof prediction.confidence === 'number' && prediction.confidence >= 70).length;
+
+  const snapshotData = [
+    { label: 'Games Tracked', value: totalGames },
+    { label: 'Expert Picks Logged', value: totalPicks },
+    { label: '70%+ Confidence', value: highConfidence },
+  ];
+
+  const grid = document.createElement('div');
+  grid.className = 'snapshot-grid';
+  snapshotData.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'snapshot-item';
+    row.innerHTML = `<strong>${item.value}</strong><span>${item.label}</span>`;
+    grid.appendChild(row);
+  });
+  snapshot.appendChild(grid);
+}
+
+function normalizeGames(games) {
+  return games.map((game) => ({
+    ...game,
+    id: game.id ?? generateId(),
+    tags: Array.isArray(game.tags) ? game.tags : [],
+    predictions: Array.isArray(game.predictions)
+      ? game.predictions.map((prediction) => ({
+          ...prediction,
+          id: prediction.id ?? generateId(),
+          confidence:
+            typeof prediction.confidence === 'number'
+              ? prediction.confidence
+              : prediction.confidence === undefined || prediction.confidence === null || prediction.confidence === ''
+              ? undefined
+              : Number(prediction.confidence),
+        }))
+      : [],
+  }));
+}
+
+function exportData() {
+  const blob = new Blob([JSON.stringify({ games: state.games }, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `football-picks-${new Date().toISOString().slice(0, 10)}.json`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+function handleImportFile(event) {
+  const [file] = event.target.files;
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (loadEvent) => {
+    try {
+      const parsed = JSON.parse(loadEvent.target.result);
+      if (!Array.isArray(parsed.games)) {
+        throw new Error('Invalid file format.');
+      }
+      state.games = normalizeGames(parsed.games);
+      persist();
+      render();
+    } catch (error) {
+      alert('Could not import data. Please ensure the JSON file was exported from this tool.');
+      console.error(error);
+    } finally {
+      selectors.importFileInput.value = '';
+    }
+  };
+  reader.readAsText(file);
+}
+
+function sampleSlate() {
+  return normalizeGames([
+    {
+      id: generateId(),
+      homeTeam: 'Kansas City Chiefs',
+      awayTeam: 'Philadelphia Eagles',
+      kickoff: 'Mon • 8:15 PM ET',
+      location: 'GEHA Field at Arrowhead Stadium',
+      tags: ['primetime', 'AFC', 'rematch'],
+      notes: 'Mahomes vs Hurts rematch. Wind 12 mph, light rain expected. Chiefs off bye week.',
+      predictions: [
+        {
+          id: generateId(),
+          source: 'PFF Forecast',
+          market: 'Spread',
+          pick: 'Chiefs -2.5',
+          line: '-110',
+          confidence: 62,
+          notes: 'Trusting KC off a bye with defensive edge',
+          link: 'https://www.pff.com',
+        },
+        {
+          id: generateId(),
+          source: 'Action Network',
+          market: 'Moneyline',
+          pick: 'Chiefs ML',
+          line: '-140',
+          confidence: 58,
+          notes: 'Model makes KC -3.2',
+          link: 'https://www.actionnetwork.com',
+        },
+        {
+          id: generateId(),
+          source: 'Sharp Clark',
+          market: 'Total',
+          pick: 'Under 47.5',
+          line: '-110',
+          confidence: 70,
+          notes: 'Both defenses top-5 in EPA over last month',
+          link: 'https://www.sharpclark.com',
+        },
+        {
+          id: generateId(),
+          source: 'Ringer Gambling Show',
+          market: 'Spread',
+          pick: 'Eagles +2.5',
+          line: '-105',
+          confidence: 55,
+          notes: 'Hurts legs can keep them in it late',
+          link: 'https://www.theringer.com',
+        },
+      ],
+    },
+    {
+      id: generateId(),
+      homeTeam: 'San Francisco 49ers',
+      awayTeam: 'Dallas Cowboys',
+      kickoff: 'Sun • 4:25 PM ET',
+      location: 'Levi\'s Stadium',
+      tags: ['NFC', 'game-of-the-week'],
+      notes: 'Cowboys on short rest after MNF. 49ers pass rush vs DAL OL injuries.',
+      predictions: [
+        {
+          id: generateId(),
+          source: 'The Athletic Beat',
+          market: 'Spread',
+          pick: '49ers -3.5',
+          line: '-115',
+          confidence: 68,
+          notes: 'Shanahan scripted plays vs DAL man coverage',
+          link: 'https://www.theathletic.com',
+        },
+        {
+          id: generateId(),
+          source: 'ESPN Analytics',
+          market: 'Moneyline',
+          pick: '49ers ML',
+          line: '-175',
+          confidence: 72,
+          notes: 'FPI gives SF 67% win probability',
+          link: 'https://www.espn.com',
+        },
+        {
+          id: generateId(),
+          source: 'Warren Sharp',
+          market: 'Total',
+          pick: 'Over 46.5',
+          line: '-110',
+          confidence: 64,
+          notes: 'Expect explosives vs aggressive defenses',
+          link: 'https://www.sharpfootballanalysis.com',
+        },
+      ],
+    },
+  ]);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Football Pick Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="toolbar">
+      <div class="toolbar__left">
+        <h1>Football Pick Intelligence Hub</h1>
+        <p class="tagline">
+          Compare expert opinions, surface consensus insights, and organize your
+          weekly card in one beautiful board.
+        </p>
+      </div>
+      <div class="toolbar__actions">
+        <button id="addGameBtn" class="btn btn--primary">➕ Add Game</button>
+        <button id="importDataBtn" class="btn">📥 Import</button>
+        <button id="exportDataBtn" class="btn">📤 Export</button>
+        <button id="sampleDataBtn" class="btn btn--ghost">🔁 Sample Slate</button>
+      </div>
+      <input
+        id="searchInput"
+        class="search"
+        type="search"
+        placeholder="Search by team, tag, expert, or pick"
+        autocomplete="off"
+      />
+    </header>
+
+    <main class="layout">
+      <aside class="sidebar">
+        <section class="panel">
+          <h2>Weekly Snapshot</h2>
+          <div id="snapshot"></div>
+        </section>
+        <section class="panel">
+          <h2>Quick Tips</h2>
+          <ul class="tips">
+            <li>
+              Use the <strong>Market</strong> field to separate moneyline, spread,
+              and totals picks for each game.
+            </li>
+            <li>
+              Add <strong>confidence ratings</strong> and line notes so you can
+              see which experts are aligned.
+            </li>
+            <li>
+              Import &amp; export JSON to keep your prep synced across devices.
+            </li>
+          </ul>
+        </section>
+      </aside>
+      <section class="content">
+        <div id="gamesContainer" class="games"></div>
+      </section>
+    </main>
+
+    <dialog id="gameDialog" class="dialog">
+      <form id="gameForm" method="dialog" class="dialog__form">
+        <header class="dialog__header">
+          <h2 id="gameDialogTitle">Add Game</h2>
+          <button type="button" class="icon-btn" data-close-dialog>✕</button>
+        </header>
+        <div class="dialog__body">
+          <label class="field">
+            <span>Home Team</span>
+            <input name="homeTeam" type="text" required placeholder="Home team" />
+          </label>
+          <label class="field">
+            <span>Away Team</span>
+            <input name="awayTeam" type="text" required placeholder="Away team" />
+          </label>
+          <label class="field">
+            <span>Kickoff (date &amp; time)</span>
+            <input name="kickoff" type="text" placeholder="Sun • 4:25 PM ET" />
+          </label>
+          <label class="field">
+            <span>Location</span>
+            <input name="location" type="text" placeholder="Arrowhead Stadium" />
+          </label>
+          <label class="field">
+            <span>Tags</span>
+            <input
+              name="tags"
+              type="text"
+              placeholder="primetime, weather, AFC"
+            />
+            <small>Comma-separated tags help filter later.</small>
+          </label>
+          <label class="field">
+            <span>Game notes</span>
+            <textarea
+              name="notes"
+              rows="3"
+              placeholder="Injuries, weather, matchup trends..."
+            ></textarea>
+          </label>
+        </div>
+        <footer class="dialog__footer">
+          <button type="button" class="btn" data-close-dialog>Cancel</button>
+          <button type="submit" class="btn btn--primary">Save Game</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <dialog id="predictionDialog" class="dialog">
+      <form id="predictionForm" method="dialog" class="dialog__form">
+        <header class="dialog__header">
+          <h2 id="predictionDialogTitle">Add Prediction</h2>
+          <button type="button" class="icon-btn" data-close-dialog>✕</button>
+        </header>
+        <div class="dialog__body">
+          <div class="form-grid">
+            <label class="field">
+              <span>Source / Expert</span>
+              <input
+                name="source"
+                type="text"
+                required
+                placeholder="PFF, Sharp Football, etc."
+              />
+            </label>
+            <label class="field">
+              <span>Market</span>
+              <input name="market" type="text" placeholder="Spread, Moneyline, Total" />
+            </label>
+          </div>
+          <label class="field">
+            <span>Pick</span>
+            <input name="pick" type="text" required placeholder="Chiefs -2.5" />
+          </label>
+          <label class="field">
+            <span>Line / Odds</span>
+            <input name="line" type="text" placeholder="-110, +145, 47.5" />
+          </label>
+          <label class="field field--inline">
+            <span>Confidence</span>
+            <div class="confidence-field">
+              <input
+                name="confidence"
+                type="range"
+                min="0"
+                max="100"
+                step="5"
+                value="50"
+              />
+              <output data-confidence-output>50%</output>
+            </div>
+          </label>
+          <label class="field">
+            <span>Reference link</span>
+            <input name="link" type="url" placeholder="https://example.com/article" />
+          </label>
+          <label class="field">
+            <span>Notes</span>
+            <textarea
+              name="notes"
+              rows="3"
+              placeholder="Context about the pick, injuries, betting angle..."
+            ></textarea>
+          </label>
+        </div>
+        <footer class="dialog__footer">
+          <button type="button" class="btn" data-close-dialog>Cancel</button>
+          <button type="submit" class="btn btn--primary">Save Pick</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <input id="importFileInput" type="file" accept="application/json" hidden />
+
+    <template id="emptyStateTemplate">
+      <div class="empty-state">
+        <p>No games added yet.</p>
+        <button class="btn btn--primary" data-empty-add>Start with a new matchup</button>
+      </div>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,542 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --bg: #0f172a;
+  --bg-alt: rgba(15, 23, 42, 0.75);
+  --panel: rgba(15, 23, 42, 0.6);
+  --panel-light: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fafc;
+  --text-muted: rgba(248, 250, 252, 0.7);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.15);
+  --danger: #f87171;
+  --warning: #fbbf24;
+  --success: #4ade80;
+  background: radial-gradient(circle at top left, #1e293b, #020617 55%);
+  color: var(--text);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+.toolbar {
+  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem) 1.5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) auto;
+  gap: 1.5rem;
+  align-items: end;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.96), rgba(2, 6, 23, 0.8));
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.toolbar h1 {
+  font-size: clamp(1.85rem, 3vw, 2.6rem);
+  margin: 0;
+  font-weight: 700;
+}
+
+.toolbar .tagline {
+  margin: 0.5rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.toolbar__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.search {
+  grid-column: 1 / -1;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1.75rem;
+  padding: 1.5rem clamp(1.5rem, 4vw, 3.5rem) 3.5rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+}
+
+.panel h2 {
+  margin: 0 0 1.25rem;
+  font-size: 1.1rem;
+}
+
+.tips {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.games {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.game-card {
+  background: var(--panel);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 35px 65px -20px rgba(15, 23, 42, 0.7);
+}
+
+.game-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 55%);
+  pointer-events: none;
+}
+
+.game-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.game-header__top {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.game-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.tag-chip {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.game-meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.game-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn,
+.icon-btn {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  transition: transform 120ms ease, box-shadow 200ms ease, background 200ms ease;
+  color: inherit;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.btn:hover,
+.icon-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px -12px rgba(56, 189, 248, 0.6);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.icon-btn {
+  padding: 0.3rem 0.45rem;
+  border-radius: 0.65rem;
+  line-height: 1;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.summary-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(56, 189, 248, 0.12);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.summary-banner strong {
+  font-size: 1.05rem;
+}
+
+.summary-bar {
+  display: flex;
+  width: 100%;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.summary-segment {
+  flex: 1;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.market-block {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.market-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.market-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.market-title h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.market-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.prediction-list {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+}
+
+.prediction {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.prediction__source {
+  grid-column: span 2;
+  font-weight: 600;
+}
+
+.prediction__pick {
+  grid-column: span 3;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.pick-pill {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.prediction__line {
+  grid-column: span 2;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.prediction__confidence {
+  grid-column: span 2;
+}
+
+.confidence-meter {
+  position: relative;
+  background: rgba(56, 189, 248, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 0.75rem;
+}
+
+.confidence-meter::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: var(--confidence, 50%);
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.7), rgba(14, 165, 233, 0.9));
+}
+
+.confidence-label {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.prediction__notes {
+  grid-column: span 3;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.prediction__actions {
+  grid-column: span 2;
+  display: flex;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
+.consensus-pill {
+  background: rgba(74, 222, 128, 0.2);
+  color: var(--success);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.dialog {
+  border: none;
+  border-radius: 1.25rem;
+  padding: 0;
+  background: rgba(15, 23, 42, 0.95);
+  color: inherit;
+  max-width: min(560px, 90vw);
+}
+
+.dialog::backdrop {
+  background: rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.dialog__form {
+  display: flex;
+  flex-direction: column;
+  max-height: 85vh;
+}
+
+.dialog__header,
+.dialog__footer {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.dialog__footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  justify-content: flex-end;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.dialog__body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field span {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+
+.field small {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.field input,
+.field textarea,
+.search {
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.85rem;
+  color: inherit;
+  font: inherit;
+}
+
+.field textarea {
+  resize: vertical;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.confidence-field {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.confidence-field input[type='range'] {
+  flex: 1;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--text-muted);
+}
+
+.empty-state .btn {
+  margin-top: 1rem;
+}
+
+.snapshot-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.snapshot-item {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 1rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.snapshot-item strong {
+  display: block;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    order: 2;
+  }
+}
+
+@media (max-width: 720px) {
+  .toolbar {
+    grid-template-columns: minmax(0, 1fr);
+    position: static;
+  }
+
+  .toolbar__actions {
+    justify-content: flex-start;
+  }
+
+  .prediction {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .prediction__source,
+  .prediction__pick,
+  .prediction__line,
+  .prediction__confidence,
+  .prediction__notes,
+  .prediction__actions {
+    grid-column: span 2;
+  }
+}


### PR DESCRIPTION
## Summary
- build a responsive "Football Pick Intelligence Hub" layout with dialogs for managing matchups and predictions
- implement dynamic rendering with consensus highlights, market grouping, confidence visuals, search filtering, and persistent local storage data
- support importing/exporting JSON slates plus a curated sample board with normalized IDs and metadata

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5e1f2de10832699fc09e911f52fb9