### PR TITLE
Enable pick reordering and priority board

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,24 @@ const state = {
   filterText: '',
 };
 
+const MARKET_LABELS = [
+  {
+    labels: ['spread', 'against the spread', 'ats', 'point spread'],
+    value: 'Spread',
+    icon: '📏',
+    description: 'Against the spread selections',
+  },
+  { labels: ['moneyline', 'money line', 'ml'], value: 'Moneyline', icon: '💰', description: 'Straight-up winners' },
+  {
+    labels: ['total', 'over/under', 'o/u', 'ou', 'over under'],
+    value: 'Total',
+    icon: '📊',
+    description: 'Game totals and tempo reads',
+  },
+  { labels: ['player prop', 'props', 'prop'], value: 'Player Prop', icon: '🎯', description: 'Individual player markets' },
+  { labels: ['team total'], value: 'Team Total', icon: '🏟️', description: 'Team scoring outlooks' },
+];
+
 function generateId() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -25,6 +43,31 @@ const selectors = {
   importFileInput: document.getElementById('importFileInput'),
   emptyTemplate: document.getElementById('emptyStateTemplate'),
 };
+
+function formatMarketLabel(input) {
+  if (!input) return 'General Picks';
+  const raw = String(input).trim();
+  if (!raw) return 'General Picks';
+  const normalized = raw.toLowerCase();
+  for (const label of MARKET_LABELS) {
+    if (label.labels.includes(normalized)) {
+      return label.value;
+    }
+  }
+  return raw;
+}
+
+function getMarketMeta(label) {
+  const normalized = formatMarketLabel(label);
+  if (!label || normalized === 'General Picks') {
+    return { icon: '🧠', description: 'Mixed markets or unspecified angles' };
+  }
+  const preset = MARKET_LABELS.find((item) => item.value === normalized);
+  if (preset) {
+    return { icon: preset.icon, description: preset.description };
+  }
+  return { icon: '📌', description: '' };
+}
 
 const dialogs = {
   game: document.getElementById('gameDialog'),
@@ -230,7 +273,7 @@ function renderGameCard(game) {
   header.appendChild(actions);
   card.appendChild(header);
 
-  const markets = groupBy(game.predictions, (prediction) => prediction.market || 'General Picks');
+  const markets = groupBy(game.predictions, (prediction) => formatMarketLabel(prediction.market));
   if (markets.size) {
     markets.forEach((predictions, market) => {
       card.appendChild(renderMarketBlock(game, market, predictions));
@@ -265,28 +308,37 @@ function renderMarketBlock(game, market, predictions) {
   titleRow.className = 'market-title';
 
   const title = document.createElement('h3');
-  title.textContent = market;
+  const meta = getMarketMeta(market);
+  const icon = document.createElement('span');
+  icon.className = 'market-icon';
+  icon.textContent = meta.icon;
+  title.appendChild(icon);
+  const titleText = document.createElement('span');
+  titleText.textContent = market;
+  title.appendChild(titleText);
   titleRow.appendChild(title);
 
-  const meta = document.createElement('span');
-  meta.className = 'market-meta';
-  meta.textContent = `${predictions.length} pick${predictions.length === 1 ? '' : 's'}`;
-  titleRow.appendChild(meta);
+  const metaText = document.createElement('span');
+  metaText.className = 'market-meta';
+  metaText.textContent = `${predictions.length} pick${predictions.length === 1 ? '' : 's'}`;
+  titleRow.appendChild(metaText);
 
   header.appendChild(titleRow);
+
+  if (meta.description) {
+    const subtitle = document.createElement('p');
+    subtitle.className = 'market-subtitle';
+    subtitle.textContent = meta.description;
+    header.appendChild(subtitle);
+  }
+
   header.appendChild(buildSummaryBar(predictions));
 
   const list = document.createElement('ul');
   list.className = 'prediction-list';
 
-  const sorted = [...predictions].sort((a, b) => {
-    const left = typeof a.confidence === 'number' ? a.confidence : -1;
-    const right = typeof b.confidence === 'number' ? b.confidence : -1;
-    return right - left;
-  });
-
-  sorted.forEach((prediction) => {
-    list.appendChild(renderPredictionItem(game, prediction));
+  predictions.forEach((prediction, index) => {
+    list.appendChild(renderPredictionItem(game, prediction, index, predictions.length));
   });
 
   block.appendChild(header);
@@ -295,15 +347,26 @@ function renderMarketBlock(game, market, predictions) {
   return block;
 }
 
-function renderPredictionItem(game, prediction) {
+function renderPredictionItem(game, prediction, index, totalInMarket) {
   const item = document.createElement('li');
   item.className = 'prediction';
   item.dataset.predictionId = prediction.id;
   item.dataset.gameId = game.id;
 
+  if (prediction.priority) {
+    item.classList.add('prediction--priority');
+  }
+
   const source = document.createElement('div');
   source.className = 'prediction__source';
   source.textContent = prediction.source;
+
+  if (prediction.priority) {
+    const priority = document.createElement('span');
+    priority.className = 'priority-indicator';
+    priority.textContent = '⭐ Priority';
+    source.appendChild(priority);
+  }
 
   const pick = document.createElement('div');
   pick.className = 'prediction__pick';
@@ -314,9 +377,11 @@ function renderPredictionItem(game, prediction) {
   pill.textContent = prediction.pick;
   pick.appendChild(pill);
   if (prediction.market) {
+    const label = formatMarketLabel(prediction.market);
+    const meta = getMarketMeta(prediction.market);
     const marketTag = document.createElement('span');
-    marketTag.className = 'tag-chip';
-    marketTag.textContent = prediction.market;
+    marketTag.className = 'market-pill';
+    marketTag.textContent = `${meta.icon} ${label}`;
     pick.appendChild(marketTag);
   }
 
@@ -364,10 +429,47 @@ function renderPredictionItem(game, prediction) {
 
   const actions = document.createElement('div');
   actions.className = 'prediction__actions';
-  actions.innerHTML = `
-    <button class="icon-btn" title="Edit" data-action="edit-prediction">✏️</button>
-    <button class="icon-btn" title="Delete" data-action="delete-prediction">🗑️</button>
-  `;
+
+  const priorityButton = document.createElement('button');
+  priorityButton.className = 'icon-btn';
+  priorityButton.dataset.action = 'toggle-priority';
+  priorityButton.title = prediction.priority ? 'Remove from priority board' : 'Highlight this pick';
+  priorityButton.textContent = prediction.priority ? '★' : '☆';
+  actions.appendChild(priorityButton);
+
+  const moveUp = document.createElement('button');
+  moveUp.className = 'icon-btn';
+  moveUp.dataset.action = 'move-prediction-up';
+  moveUp.title = 'Move up';
+  moveUp.textContent = '⬆️';
+  if (index === 0) {
+    moveUp.disabled = true;
+  }
+  actions.appendChild(moveUp);
+
+  const moveDown = document.createElement('button');
+  moveDown.className = 'icon-btn';
+  moveDown.dataset.action = 'move-prediction-down';
+  moveDown.title = 'Move down';
+  moveDown.textContent = '⬇️';
+  if (index === totalInMarket - 1) {
+    moveDown.disabled = true;
+  }
+  actions.appendChild(moveDown);
+
+  const edit = document.createElement('button');
+  edit.className = 'icon-btn';
+  edit.dataset.action = 'edit-prediction';
+  edit.title = 'Edit';
+  edit.textContent = '✏️';
+  actions.appendChild(edit);
+
+  const remove = document.createElement('button');
+  remove.className = 'icon-btn';
+  remove.dataset.action = 'delete-prediction';
+  remove.title = 'Delete';
+  remove.textContent = '🗑️';
+  actions.appendChild(remove);
 
   item.appendChild(source);
   item.appendChild(pick);
@@ -465,13 +567,19 @@ function handlePredictionSubmit(event) {
   }
   const payload = {
     id: state.editingPrediction?.id ?? generateId(),
-    source: formData.get('source').trim(),
-    market: formData.get('market').trim(),
-    pick: formData.get('pick').trim(),
-    line: formData.get('line').trim(),
-    confidence: Number(formData.get('confidence')),
-    notes: formData.get('notes').trim(),
-    link: formData.get('link').trim(),
+    source: (formData.get('source') || '').trim(),
+    market: (formData.get('market') || '').trim(),
+    pick: (formData.get('pick') || '').trim(),
+    line: (formData.get('line') || '').trim(),
+    confidence: (() => {
+      const value = formData.get('confidence');
+      if (value === null || value === undefined || value === '') return undefined;
+      const numeric = Number(value);
+      return Number.isNaN(numeric) ? undefined : numeric;
+    })(),
+    notes: (formData.get('notes') || '').trim(),
+    link: (formData.get('link') || '').trim(),
+    priority: formData.has('priority'),
   };
 
   if (!payload.source || !payload.pick) {
@@ -531,6 +639,21 @@ function handleGameAction(event) {
       deletePrediction(gameId, predictionId);
       break;
     }
+    case 'move-prediction-up': {
+      const predictionId = button.closest('.prediction').dataset.predictionId;
+      movePrediction(gameId, predictionId, -1);
+      break;
+    }
+    case 'move-prediction-down': {
+      const predictionId = button.closest('.prediction').dataset.predictionId;
+      movePrediction(gameId, predictionId, 1);
+      break;
+    }
+    case 'toggle-priority': {
+      const predictionId = button.closest('.prediction').dataset.predictionId;
+      togglePredictionPriority(gameId, predictionId);
+      break;
+    }
     default:
       break;
   }
@@ -547,6 +670,48 @@ function deletePrediction(gameId, predictionId) {
   const game = state.games.find((item) => item.id === gameId);
   if (!game) return;
   game.predictions = game.predictions.filter((prediction) => prediction.id !== predictionId);
+  persist();
+  render();
+}
+
+function movePrediction(gameId, predictionId, direction) {
+  const game = state.games.find((item) => item.id === gameId);
+  if (!game) return;
+  const working = [...game.predictions];
+  const index = working.findIndex((prediction) => prediction.id === predictionId);
+  if (index < 0) return;
+
+  const targetMarket = formatMarketLabel(working[index].market);
+  const marketOrder = working
+    .map((prediction, idx) => ({ prediction, idx }))
+    .filter((entry) => formatMarketLabel(entry.prediction.market) === targetMarket);
+
+  const marketPosition = marketOrder.findIndex((entry) => entry.idx === index);
+  if (marketPosition < 0) return;
+
+  const swapEntry = marketOrder[marketPosition + direction];
+  if (!swapEntry) return;
+
+  const [moving] = working.splice(index, 1);
+  let insertionIndex = swapEntry.idx;
+  if (swapEntry.idx > index) {
+    insertionIndex -= 1;
+  }
+  if (direction > 0) {
+    insertionIndex += 1;
+  }
+  working.splice(insertionIndex, 0, moving);
+  game.predictions = working;
+  persist();
+  render();
+}
+
+function togglePredictionPriority(gameId, predictionId) {
+  const game = state.games.find((item) => item.id === gameId);
+  if (!game) return;
+  const prediction = game.predictions.find((item) => item.id === predictionId);
+  if (!prediction) return;
+  prediction.priority = !prediction.priority;
   persist();
   render();
 }
@@ -578,6 +743,7 @@ function openPredictionDialog(game, prediction) {
   forms.prediction.line.value = prediction?.line ?? '';
   forms.prediction.link.value = prediction?.link ?? '';
   forms.prediction.notes.value = prediction?.notes ?? '';
+  forms.prediction.priority.checked = Boolean(prediction?.priority);
   openDialog(dialogs.prediction);
 }
 
@@ -645,23 +811,291 @@ function renderSnapshot() {
     grid.appendChild(row);
   });
   snapshot.appendChild(grid);
+
+  const marketBreakdown = buildMarketBreakdown(state.games);
+  if (marketBreakdown) {
+    snapshot.appendChild(marketBreakdown);
+  }
+
+  const priorityBoard = buildPriorityBoard(state.games);
+  if (priorityBoard) {
+    snapshot.appendChild(priorityBoard);
+  }
+
+  const consensusLeaders = buildConsensusLeaders(state.games);
+  if (consensusLeaders) {
+    snapshot.appendChild(consensusLeaders);
+  }
+
+  const confidenceLeaders = buildConfidenceLeaders(state.games);
+  if (confidenceLeaders) {
+    snapshot.appendChild(confidenceLeaders);
+  }
+}
+
+function createSnapshotSection(titleText) {
+  const section = document.createElement('section');
+  section.className = 'snapshot-section';
+  const title = document.createElement('h3');
+  title.className = 'snapshot-section__title';
+  title.textContent = titleText;
+  section.appendChild(title);
+  return section;
+}
+
+function buildMarketBreakdown(games) {
+  const counts = new Map();
+  let total = 0;
+  games.forEach((game) => {
+    game.predictions.forEach((prediction) => {
+      total += 1;
+      const label = formatMarketLabel(prediction.market);
+      counts.set(label, (counts.get(label) || 0) + 1);
+    });
+  });
+
+  if (!total) return null;
+
+  const section = createSnapshotSection('Market Coverage');
+  const list = document.createElement('ul');
+  list.className = 'snapshot-list';
+
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  entries.forEach(([market, count]) => {
+    const item = document.createElement('li');
+    item.className = 'snapshot-row';
+    const meta = getMarketMeta(market);
+
+    const chip = document.createElement('span');
+    chip.className = 'snapshot-chip';
+    chip.textContent = `${meta.icon} ${market}`;
+    item.appendChild(chip);
+
+    const metric = document.createElement('span');
+    metric.className = 'snapshot-metric';
+    const percent = Math.round((count / total) * 100);
+    metric.textContent = `${count} pick${count === 1 ? '' : 's'} • ${percent}%`;
+    item.appendChild(metric);
+
+    list.appendChild(item);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+function buildPriorityBoard(games) {
+  const entries = [];
+  games.forEach((game) => {
+    game.predictions.forEach((prediction, index) => {
+      if (prediction.priority) {
+        entries.push({ game, prediction, order: index });
+      }
+    });
+  });
+
+  if (!entries.length) return null;
+
+  entries.sort((a, b) => {
+    const left = typeof a.prediction.confidence === 'number' ? a.prediction.confidence : -1;
+    const right = typeof b.prediction.confidence === 'number' ? b.prediction.confidence : -1;
+    if (right === left) {
+      return a.order - b.order;
+    }
+    return right - left;
+  });
+
+  const section = createSnapshotSection('Priority Picks Board');
+  const list = document.createElement('ul');
+  list.className = 'snapshot-list snapshot-list--stacked';
+
+  entries.slice(0, 6).forEach(({ game, prediction }) => {
+    const item = document.createElement('li');
+    item.className = 'snapshot-row snapshot-row--stacked snapshot-row--priority';
+
+    const header = document.createElement('div');
+    header.className = 'snapshot-row__header';
+
+    const badge = document.createElement('span');
+    badge.className = 'snapshot-badge snapshot-badge--priority';
+    badge.textContent = '★';
+    header.appendChild(badge);
+
+    const source = document.createElement('span');
+    source.className = 'snapshot-source';
+    source.textContent = prediction.source;
+    header.appendChild(source);
+
+    if (prediction.market) {
+      const market = document.createElement('span');
+      market.className = 'snapshot-subtext';
+      market.textContent = `${getMarketMeta(prediction.market).icon} ${formatMarketLabel(prediction.market)}`;
+      header.appendChild(market);
+    }
+
+    if (typeof prediction.confidence === 'number') {
+      const confidence = document.createElement('span');
+      confidence.className = 'snapshot-pill';
+      confidence.textContent = `${prediction.confidence}%`; 
+      header.appendChild(confidence);
+    }
+
+    item.appendChild(header);
+
+    const detail = document.createElement('div');
+    detail.className = 'snapshot-subtext';
+    const odds = prediction.line ? ` (${prediction.line})` : '';
+    detail.textContent = `${formatMatchup(game)} • ${prediction.pick}${odds}`;
+    item.appendChild(detail);
+
+    list.appendChild(item);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+function buildConsensusLeaders(games) {
+  const leaders = games
+    .map((game) => ({ game, summary: buildConsensusSummary(game.predictions) }))
+    .filter((entry) => entry.summary)
+    .sort((a, b) => b.summary.percent - a.summary.percent)
+    .slice(0, 3);
+
+  if (!leaders.length) return null;
+
+  const section = createSnapshotSection('Consensus Board (40%+ alignment)');
+  const list = document.createElement('ul');
+  list.className = 'snapshot-list snapshot-list--stacked';
+
+  leaders.forEach(({ game, summary }) => {
+    const item = document.createElement('li');
+    item.className = 'snapshot-row snapshot-row--stacked';
+
+    const header = document.createElement('div');
+    header.className = 'snapshot-row__header';
+    const badge = document.createElement('span');
+    badge.className = 'snapshot-badge snapshot-badge--consensus';
+    badge.textContent = `${summary.percent}%`;
+    header.appendChild(badge);
+
+    const pick = document.createElement('strong');
+    pick.textContent = summary.pick;
+    header.appendChild(pick);
+    item.appendChild(header);
+
+    const detail = document.createElement('div');
+    detail.className = 'snapshot-subtext';
+    detail.textContent = `${formatMatchup(game)} • ${summary.count} of ${summary.total} sources aligned`;
+    item.appendChild(detail);
+
+    list.appendChild(item);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+function buildConfidenceLeaders(games) {
+  const entries = [];
+  games.forEach((game) => {
+    game.predictions.forEach((prediction) => {
+      if (typeof prediction.confidence === 'number' && !Number.isNaN(prediction.confidence)) {
+        entries.push({ game, prediction });
+      }
+    });
+  });
+
+  if (!entries.length) return null;
+
+  entries.sort((a, b) => b.prediction.confidence - a.prediction.confidence);
+  const top = entries.slice(0, 5);
+
+  const section = createSnapshotSection('Highest Confidence Board');
+  const list = document.createElement('ul');
+  list.className = 'snapshot-list snapshot-list--stacked';
+
+  top.forEach(({ game, prediction }) => {
+    const item = document.createElement('li');
+    item.className = 'snapshot-row snapshot-row--stacked';
+
+    const header = document.createElement('div');
+    header.className = 'snapshot-row__header';
+
+    const badge = document.createElement('span');
+    badge.className = 'snapshot-badge';
+    badge.textContent = `${prediction.confidence}%`;
+    header.appendChild(badge);
+
+    const source = document.createElement('span');
+    source.className = 'snapshot-source';
+    source.textContent = prediction.source;
+    header.appendChild(source);
+
+    if (prediction.market) {
+      const market = document.createElement('span');
+      market.className = 'snapshot-subtext';
+      market.textContent = `${getMarketMeta(prediction.market).icon} ${formatMarketLabel(prediction.market)}`;
+      header.appendChild(market);
+    }
+
+    item.appendChild(header);
+
+    const detail = document.createElement('div');
+    detail.className = 'snapshot-subtext';
+    const odds = prediction.line ? ` (${prediction.line})` : '';
+    detail.textContent = `${formatMatchup(game)} • ${prediction.pick}${odds}`;
+    item.appendChild(detail);
+
+    list.appendChild(item);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+function formatMatchup(game) {
+  if (!game) return '';
+  const away = game.awayTeam || 'Away';
+  const home = game.homeTeam || 'Home';
+  return `${away} @ ${home}`;
 }
 
 function normalizeGames(games) {
   return games.map((game) => ({
     ...game,
     id: game.id ?? generateId(),
-    tags: Array.isArray(game.tags) ? game.tags : [],
+    homeTeam: typeof game.homeTeam === 'string' ? game.homeTeam.trim() : game.homeTeam,
+    awayTeam: typeof game.awayTeam === 'string' ? game.awayTeam.trim() : game.awayTeam,
+    kickoff: typeof game.kickoff === 'string' ? game.kickoff.trim() : game.kickoff,
+    location: typeof game.location === 'string' ? game.location.trim() : game.location,
+    notes: typeof game.notes === 'string' ? game.notes.trim() : game.notes,
+    tags: Array.isArray(game.tags) ? game.tags.map((tag) => (typeof tag === 'string' ? tag.trim() : tag)).filter(Boolean) : [],
     predictions: Array.isArray(game.predictions)
       ? game.predictions.map((prediction) => ({
           ...prediction,
           id: prediction.id ?? generateId(),
+          source: typeof prediction.source === 'string' ? prediction.source.trim() : prediction.source,
+          market:
+            typeof prediction.market === 'string'
+              ? prediction.market.trim()
+              : prediction.market
+              ? String(prediction.market)
+              : '',
+          pick: typeof prediction.pick === 'string' ? prediction.pick.trim() : prediction.pick,
+          line: typeof prediction.line === 'string' ? prediction.line.trim() : prediction.line,
+          notes: typeof prediction.notes === 'string' ? prediction.notes.trim() : prediction.notes,
+          link: typeof prediction.link === 'string' ? prediction.link.trim() : prediction.link,
           confidence:
             typeof prediction.confidence === 'number'
               ? prediction.confidence
               : prediction.confidence === undefined || prediction.confidence === null || prediction.confidence === ''
               ? undefined
               : Number(prediction.confidence),
+          priority:
+            typeof prediction.priority === 'string'
+              ? prediction.priority.toLowerCase() === 'true'
+              : Boolean(prediction.priority),
         }))
       : [],
   }));
@@ -724,6 +1158,7 @@ function sampleSlate() {
           confidence: 62,
           notes: 'Trusting KC off a bye with defensive edge',
           link: 'https://www.pff.com',
+          priority: true,
         },
         {
           id: generateId(),
@@ -744,6 +1179,7 @@ function sampleSlate() {
           confidence: 70,
           notes: 'Both defenses top-5 in EPA over last month',
           link: 'https://www.sharpclark.com',
+          priority: true,
         },
         {
           id: generateId(),
@@ -775,6 +1211,7 @@ function sampleSlate() {
           confidence: 68,
           notes: 'Shanahan scripted plays vs DAL man coverage',
           link: 'https://www.theathletic.com',
+          priority: true,
         },
         {
           id: generateId(),
@@ -785,6 +1222,7 @@ function sampleSlate() {
           confidence: 72,
           notes: 'FPI gives SF 67% win probability',
           link: 'https://www.espn.com',
+          priority: true,
         },
         {
           id: generateId(),
@@ -795,6 +1233,69 @@ function sampleSlate() {
           confidence: 64,
           notes: 'Expect explosives vs aggressive defenses',
           link: 'https://www.sharpfootballanalysis.com',
+        },
+        {
+          id: generateId(),
+          source: 'RotoGrinders Betting',
+          market: 'Team Total',
+          pick: '49ers team total over 24.5',
+          line: '-115',
+          confidence: 61,
+          notes: 'Dallas defensive splits dip outdoors; SF offense rolling',
+          link: 'https://rotogrinders.com',
+        },
+      ],
+    },
+    {
+      id: generateId(),
+      homeTeam: 'Baltimore Ravens',
+      awayTeam: 'Miami Dolphins',
+      kickoff: 'Sun • 1:00 PM ET',
+      location: "M&T Bank Stadium",
+      tags: ['AFC', 'weather watch'],
+      notes: 'Forecast calling for breezy conditions. Monitor OL injuries for Miami.',
+      predictions: [
+        {
+          id: generateId(),
+          source: 'BettingPros Consensus',
+          market: 'Spread',
+          pick: 'Ravens -3',
+          line: '-115',
+          confidence: 60,
+          notes: 'Market shading toward Baltimore with injury concerns for Dolphins OL',
+          link: 'https://www.bettingpros.com',
+          priority: true,
+        },
+        {
+          id: generateId(),
+          source: 'Establish The Run',
+          market: 'Player Prop',
+          pick: 'Lamar Jackson over 58.5 rush yds',
+          line: '-120',
+          confidence: 74,
+          notes: 'Miami man coverage opens rushing lanes for QB scrambles',
+          link: 'https://establishtherun.com',
+          priority: true,
+        },
+        {
+          id: generateId(),
+          source: 'The Lines Podcast',
+          market: 'Moneyline',
+          pick: 'Ravens ML',
+          line: '-160',
+          confidence: 65,
+          notes: 'Trusting Harbaugh off mini-bye with rest advantage',
+          link: 'https://www.thelines.com',
+        },
+        {
+          id: generateId(),
+          source: 'VEGAS Insider',
+          market: 'Total',
+          pick: 'Over 49.5',
+          line: '-108',
+          confidence: 52,
+          notes: 'Projected pace increase with explosive playmakers on both sides',
+          link: 'https://www.vegasinsider.com',
         },
       ],
     },

--- a/index.html
+++ b/index.html
@@ -54,6 +54,10 @@
               see which experts are aligned.
             </li>
             <li>
+              Glance at the <strong>Weekly Snapshot</strong> to surface consensus
+              edges and the most confident recommendations.
+            </li>
+            <li>
               Import &amp; export JSON to keep your prep synced across devices.
             </li>
           </ul>
@@ -131,7 +135,12 @@
             </label>
             <label class="field">
               <span>Market</span>
-              <input name="market" type="text" placeholder="Spread, Moneyline, Total" />
+              <input
+                name="market"
+                type="text"
+                placeholder="Spread, Moneyline, Total"
+                list="marketSuggestions"
+              />
             </label>
           </div>
           <label class="field">
@@ -156,6 +165,13 @@
               <output data-confidence-output>50%</output>
             </div>
           </label>
+          <div class="field field--choice">
+            <span>Priority</span>
+            <label class="checkbox">
+              <input name="priority" type="checkbox" />
+              <span>Highlight this pick and surface it in the Priority Board</span>
+            </label>
+          </div>
           <label class="field">
             <span>Reference link</span>
             <input name="link" type="url" placeholder="https://example.com/article" />
@@ -177,6 +193,18 @@
     </dialog>
 
     <input id="importFileInput" type="file" accept="application/json" hidden />
+
+    <datalist id="marketSuggestions">
+      <option value="Spread"></option>
+      <option value="Moneyline"></option>
+      <option value="Total"></option>
+      <option value="Player Prop"></option>
+      <option value="Team Total"></option>
+      <option value="First Half"></option>
+      <option value="Second Half"></option>
+      <option value="Alt Line"></option>
+      <option value="Same Game Parlay"></option>
+    </datalist>
 
     <template id="emptyStateTemplate">
       <div class="empty-state">

--- a/styles.css
+++ b/styles.css
@@ -221,6 +221,11 @@ a:hover {
   background: rgba(148, 163, 184, 0.18);
 }
 
+.icon-btn[disabled] {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .summary-banner {
   display: flex;
   align-items: center;
@@ -282,11 +287,24 @@ a:hover {
 .market-title h3 {
   margin: 0;
   font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
 .market-meta {
   color: var(--text-muted);
   font-size: 0.85rem;
+}
+
+.market-icon {
+  font-size: 1.05rem;
+}
+
+.market-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
 }
 
 .prediction-list {
@@ -311,6 +329,10 @@ a:hover {
 .prediction__source {
   grid-column: span 2;
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
 }
 
 .prediction__pick {
@@ -327,6 +349,20 @@ a:hover {
   border: 1px solid rgba(59, 130, 246, 0.3);
   font-size: 0.8rem;
   font-weight: 600;
+}
+
+.market-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
 }
 
 .prediction__line {
@@ -373,6 +409,26 @@ a:hover {
   display: flex;
   gap: 0.4rem;
   justify-content: flex-end;
+}
+
+.prediction--priority {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 12px 30px -18px rgba(250, 204, 21, 0.4);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.1), rgba(15, 23, 42, 0.6));
+}
+
+.priority-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(250, 204, 21, 0.18);
+  color: #facc15;
+  font-weight: 600;
 }
 
 .consensus-pill {
@@ -460,6 +516,32 @@ a:hover {
   resize: vertical;
 }
 
+.field--choice {
+  gap: 0.5rem;
+}
+
+.checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.1rem;
+  accent-color: #facc15;
+}
+
+.checkbox span {
+  font-size: 0.85rem;
+  text-transform: none;
+  letter-spacing: normal;
+  color: inherit;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -505,6 +587,115 @@ a:hover {
   display: block;
   font-size: 0.95rem;
   margin-bottom: 0.25rem;
+}
+
+.snapshot-section {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.snapshot-section__title {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.snapshot-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.snapshot-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.snapshot-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.snapshot-metric {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.snapshot-list--stacked .snapshot-row {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.snapshot-row--stacked {
+  width: 100%;
+  gap: 0.4rem;
+}
+
+.snapshot-row__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.snapshot-badge {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.snapshot-row--priority {
+  border-color: rgba(250, 204, 21, 0.28);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.08), rgba(15, 23, 42, 0.55));
+}
+
+.snapshot-badge--priority {
+  background: rgba(250, 204, 21, 0.2);
+  color: #facc15;
+  font-size: 0.9rem;
+  letter-spacing: 0;
+  padding: 0.2rem 0.45rem;
+}
+
+.snapshot-pill {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.snapshot-badge--consensus {
+  background: rgba(74, 222, 128, 0.18);
+  color: var(--success);
+}
+
+.snapshot-source {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.snapshot-subtext {
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary
- add in-card controls so picks can be reordered per market and highlight their importance with a star toggle
- surface starred selections in a new Priority Picks Board snapshot view and apply premium styling cues
- extend the prediction form and sample slate to capture priority flags alongside the existing metadata

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d5ee8dd3b883269b4ca0a764011ad4