### PR TITLE
Handle non-finite confidence values

### DIFF
--- a/app.js
+++ b/app.js
@@ -386,7 +386,7 @@ function renderPredictionItem(game, prediction) {
 
   const confidence = document.createElement('div');
   confidence.className = 'prediction__confidence';
-  if (typeof prediction.confidence === 'number') {
+  if (Number.isFinite(prediction.confidence)) {
     const meter = document.createElement('div');
     meter.className = 'confidence-meter';
     meter.style.setProperty('--confidence', `${prediction.confidence}%`);
@@ -909,12 +909,16 @@ function normalizeGames(games) {
           line: typeof prediction.line === 'string' ? prediction.line.trim() : prediction.line,
           notes: typeof prediction.notes === 'string' ? prediction.notes.trim() : prediction.notes,
           link: typeof prediction.link === 'string' ? prediction.link.trim() : prediction.link,
-          confidence:
-            typeof prediction.confidence === 'number'
-              ? prediction.confidence
-              : prediction.confidence === undefined || prediction.confidence === null || prediction.confidence === ''
-              ? undefined
-              : Number(prediction.confidence),
+          confidence: (() => {
+            if (prediction.confidence === undefined || prediction.confidence === null || prediction.confidence === '') {
+              return undefined;
+            }
+            if (typeof prediction.confidence === 'number') {
+              return Number.isFinite(prediction.confidence) ? prediction.confidence : undefined;
+            }
+            const coerced = Number(prediction.confidence);
+            return Number.isFinite(coerced) ? coerced : undefined;
+          })(),
         }))
       : [],
   }));


### PR DESCRIPTION
## Summary
- sanitize prediction confidence values during normalization so non-finite values are dropped
- guard confidence meter rendering behind a finite confidence check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5f81f8c888326bdf8e242ce8c1d48